### PR TITLE
SPRK-128: Rename clips_per_node

### DIFF
--- a/Documentation/source/userguide/userguide.md
+++ b/Documentation/source/userguide/userguide.md
@@ -627,14 +627,14 @@ number_of_runs_in_parallel = 25
 >
 > description: The number of configuration runs that can run in parallel. 
 
-`clis_per_node`
+`max_parallel_runs_per_node`
 > aliases: N/A
 >
 > values: integer
 >
 > note: Not really a Slurm option, will likely be moved to another section.
 >
-> description: The number of parallel processes that can be run on one compute node. In case a node has 32 cores and each solver uses 2 cores, the `cli_per_node` is at most 16.
+> description: The number of parallel processes that can be run on one compute node. In case a node has 32 cores and each solver uses 2 cores, the `max_parallel_runs_per_node` is at most 16.
 
 ### Priorities
 

--- a/Examples/Resources/CVRP/Scenarios/VRP_SISRs/sparkle_settings_softcutoff.ini
+++ b/Examples/Resources/CVRP/Scenarios/VRP_SISRs/sparkle_settings_softcutoff.ini
@@ -21,4 +21,4 @@ racing = False
 number_of_runs_in_parallel = 250
 # Maximum number of concurrent runs a node can handle.
 # This can be limited by the number of cores or the amount of memory.
-clis_per_node = 32
+max_parallel_runs_per_node = 32

--- a/Examples/Resources/CVRP/Scenarios/VRP_SISRs/sparkle_settings_strongcutoff.ini
+++ b/Examples/Resources/CVRP/Scenarios/VRP_SISRs/sparkle_settings_strongcutoff.ini
@@ -21,4 +21,4 @@ racing = False
 number_of_runs_in_parallel = 250
 # Maximum number of concurrent runs a node can handle.
 # This can be limited by the number of cores or the amount of memory.
-clis_per_node = 32
+max_parallel_runs_per_node = 32

--- a/Settings/sparkle_settings.ini
+++ b/Settings/sparkle_settings.ini
@@ -24,4 +24,4 @@ process_monitoring = REALISTIC
 number_of_runs_in_parallel = 25
 # Maximum number of concurrent runs a node can handle.
 # This can be limited by the number of cores or the amount of memory.
-clis_per_node = 8
+max_parallel_runs_per_node = 8

--- a/sparkle/configurator/ablation.py
+++ b/sparkle/configurator/ablation.py
@@ -90,7 +90,7 @@ def create_configuration_file(solver_name: str, instance_train_name: str,
     smac_run_obj = smac_help.get_smac_run_obj()
     smac_each_run_cutoff_length = gv.settings.get_smac_target_cutoff_length()
     smac_each_run_cutoff_time = gv.settings.get_general_target_cutoff_time()
-    concurrent_clis = gv.settings.get_slurm_clis_per_node()
+    concurrent_clis = gv.settings.get_slurm_max_parallel_runs_per_node()
     ablation_racing = gv.settings.get_ablation_racing_flag()
     configurator = gv.settings.get_general_sparkle_configurator()
 
@@ -214,7 +214,7 @@ def submit_ablation(ablation_scenario_dir: str,
     # the Log/Ablation/.. folder.
 
     # 1. submit the ablation to the runrunner queue
-    clis = gv.settings.get_slurm_clis_per_node()
+    clis = gv.settings.get_slurm_max_parallel_runs_per_node()
     cmd = "../../ablationAnalysis --optionFile ablation_config.txt"
     srun_options = ["-N1", "-n1", f"-c{clis}"]
     sbatch_options = [f"--cpus-per-task={clis}"] +\

--- a/sparkle/platform/settings_help.py
+++ b/sparkle/platform/settings_help.py
@@ -82,7 +82,7 @@ class Settings:
     DEFAULT_config_number_of_runs = 25
 
     DEFAULT_slurm_number_of_runs_in_parallel = 25
-    DEFAULT_slurm_clis_per_node = 8
+    DEFAULT_slurm_max_parallel_runs_per_node = 8
 
     DEFAULT_smac_target_cutoff_length = "max"
 
@@ -112,7 +112,7 @@ class Settings:
         self.__config_number_of_runs_set = SettingState.NOT_SET
 
         self.__slurm_number_of_runs_in_parallel_set = SettingState.NOT_SET
-        self.__slurm_clis_per_node_set = SettingState.NOT_SET
+        self.__slurm_max_parallel_runs_per_node_set = SettingState.NOT_SET
         self.__slurm_extra_options_set = dict()
         self.__smac_target_cutoff_length_set = SettingState.NOT_SET
         self.__ablation_racing_flag_set = SettingState.NOT_SET
@@ -236,11 +236,11 @@ class Settings:
                     file_settings.remove_option(section, option)
 
             section = "slurm"
-            option_names = ("clis_per_node", )
+            option_names = ("max_parallel_runs_per_node", )
             for option in option_names:
                 if file_settings.has_option(section, option):
                     value = file_settings.getint(section, option)
-                    self.set_slurm_clis_per_node(value, state)
+                    self.set_slurm_max_parallel_runs_per_node(value, state)
                     file_settings.remove_option(section, option)
 
             section = "smac"
@@ -714,26 +714,28 @@ class Settings:
 
         return int(self.__settings["slurm"]["number_of_runs_in_parallel"])
 
-    def set_slurm_clis_per_node(self: Settings, value: int = DEFAULT_slurm_clis_per_node,
-                                origin: SettingState = SettingState.DEFAULT) -> None:
+    def set_slurm_max_parallel_runs_per_node(
+            self: Settings,
+            value: int = DEFAULT_slurm_max_parallel_runs_per_node,
+            origin: SettingState = SettingState.DEFAULT) -> None:
         """Set the number of algorithms Slurm can run in parallel per node."""
         section = "slurm"
-        name = "clis_per_node"
+        name = "max_parallel_runs_per_node"
 
         if value is not None and self.__check_setting_state(
-                self.__slurm_clis_per_node_set, origin, name):
+                self.__slurm_max_parallel_runs_per_node_set, origin, name):
             self.__init_section(section)
-            self.__slurm_clis_per_node_set = origin
+            self.__slurm_max_parallel_runs_per_node_set = origin
             self.__settings[section][name] = str(value)
 
         return
 
-    def get_slurm_clis_per_node(self: Settings) -> int:
+    def get_slurm_max_parallel_runs_per_node(self: Settings) -> int:
         """Return the number of algorithms Slurm can run in parallel per node."""
-        if self.__slurm_clis_per_node_set == SettingState.NOT_SET:
-            self.set_slurm_clis_per_node()
+        if self.__slurm_max_parallel_runs_per_node_set == SettingState.NOT_SET:
+            self.set_slurm_max_parallel_runs_per_node()
 
-        return int(self.__settings["slurm"]["clis_per_node"])
+        return int(self.__settings["slurm"]["max_parallel_runs_per_node"])
 
     # SLURM extra options
 


### PR DESCRIPTION
The option clip_per_node is now called max_parallel_runs_per_node.