### PR TITLE
Improve status monitoring with logfile status

### DIFF
--- a/CLI/system_status.py
+++ b/CLI/system_status.py
@@ -38,4 +38,9 @@ if __name__ == "__main__":
     sssh.print_list_remaining_performance_computation_job(
         gv.performance_data_csv_path, args.verbose
     )
-    print("Current system status of Sparkle reported!")
+
+    # scan configurator log files for warnings
+    configurator = gv.settings.get_general_sparkle_configurator()
+    configurator.get_status_from_logs()
+
+    print("\nCurrent system status of Sparkle reported!")

--- a/sparkle/configurator/configurator.py
+++ b/sparkle/configurator/configurator.py
@@ -87,3 +87,7 @@ class Configurator:
                           solver: str | Solver, instance_set_name: str) -> None:
         """Patching method to allow the rebuilding of configuration scenario."""
         raise NotImplementedError
+
+    def get_status_from_logs(self: Configurator) -> None:
+        """Method to scan the log files of the configurator for warnings."""
+        raise NotImplementedError

--- a/sparkle/configurator/implementations/smac2.py
+++ b/sparkle/configurator/implementations/smac2.py
@@ -187,8 +187,9 @@ class SMAC2(Configurator):
 
     def get_status_from_logs(self: SMAC2) -> None:
         """Method to scan the log files of the configurator for warnings."""
-        # print header
-        print("Checking configurator log files for warnings...")
+        # print the header
+        print(f"Checking the log files of configurator {type(self).__name__} for "
+              "warnings...")
         base_dir = self.output_path / "scenarios"
         scenarios = [f for f in base_dir.iterdir() if f.is_dir()]
         for scenario in scenarios:

--- a/sparkle/configurator/implementations/smac2.py
+++ b/sparkle/configurator/implementations/smac2.py
@@ -187,17 +187,20 @@ class SMAC2(Configurator):
 
     def get_status_from_logs(self: SMAC2) -> None:
         """Method to scan the log files of the configurator for warnings."""
+        # print header
+        print("Checking configurator log files for warnings...")
         base_dir = self.output_path / "scenarios"
         scenarios = [f for f in base_dir.iterdir() if f.is_dir()]
         for scenario in scenarios:
             log_dir = scenario / "outdir_train_configuration" \
                 / (scenario.name + "_scenario")
             warn_files = glob.glob(str(log_dir) + "/log-warn*")
-            non_empty = [f for f in warn_files if Path(f).stat().st_size > 0]
+            non_empty = [log_file for log_file in warn_files
+                         if Path(log_file).stat().st_size > 0]
             if len(non_empty) > 0:
                 print(f"Scenario {scenario.name} has {len(non_empty)} warning(s), see "
                       "the following log file(s) for more information:")
-                for f in non_empty:
-                    print("  ", f)
+                for log_file in non_empty:
+                    print(f"\t-{log_file}")
             else:
                 print(f"Scenario {scenario.name} has no warnings.")

--- a/sparkle/configurator/implementations/smac2.py
+++ b/sparkle/configurator/implementations/smac2.py
@@ -10,6 +10,7 @@ from statistics import mean
 import operator
 import fcntl
 import shutil
+import glob
 
 import runrunner as rrr
 from runrunner import Runner
@@ -183,3 +184,20 @@ class SMAC2(Configurator):
             solver = Solver.get_solver_by_name(solver)
         self.scenario = ConfigurationScenario(solver, Path(instance_set_name))
         self.scenario._set_paths(self.output_path)
+
+    def get_status_from_logs(self: SMAC2) -> None:
+        """Method to scan the log files of the configurator for warnings."""
+        base_dir = self.output_path / "scenarios"
+        scenarios = [f for f in base_dir.iterdir() if f.is_dir()]
+        for scenario in scenarios:
+            log_dir = scenario / "outdir_train_configuration" \
+                / (scenario.name + "_scenario")
+            warn_files = glob.glob(str(log_dir) + "/log-warn*")
+            non_empty = [f for f in warn_files if Path(f).stat().st_size > 0]
+            if len(non_empty) > 0:
+                print(f"Scenario {scenario.name} has {len(non_empty)} warning(s), see "
+                      "the following log file(s) for more information:")
+                for f in non_empty:
+                    print("  ", f)
+            else:
+                print(f"Scenario {scenario.name} has no warnings.")


### PR DESCRIPTION
Scan all the log-warn.txt files generated during configuration runs to see if we encountered any issues. Print the paths to all the non-empty log files so the user can inspect them.