### PR TITLE
Add default value for the run-on argument

### DIFF
--- a/CLI/add_instances.py
+++ b/CLI/add_instances.py
@@ -17,6 +17,7 @@ import sparkle_logging as sl
 from CLI.help import command_help as ch
 from CLI.initialise import check_for_initialise
 from CLI.help import argparse_custom as apc
+from sparkle.platform.settings_help import SettingState
 
 
 def parser_function() -> argparse.ArgumentParser:
@@ -57,7 +58,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
     instances_source = Path(args.instances_path)
     instances_target = gv.instance_dir / instances_source.name
-    run_on = args.run_on
+
+    if args.run_on is not None:
+        gv.settings.set_run_on(
+            args.run_on, SettingState.CMD_LINE)
+    run_on = gv.settings.get_run_on()
 
     check_for_initialise(sys.argv,
                          ch.COMMAND_DEPENDENCIES[ch.CommandName.ADD_INSTANCES])

--- a/CLI/add_instances.py
+++ b/CLI/add_instances.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 
     if args.run_on is not None:
         gv.settings.set_run_on(
-            args.run_on, SettingState.CMD_LINE)
+            args.run_on.value, SettingState.CMD_LINE)
     run_on = gv.settings.get_run_on()
 
     check_for_initialise(sys.argv,

--- a/CLI/add_solver.py
+++ b/CLI/add_solver.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
 
     if args.run_on is not None:
         gv.settings.set_run_on(
-            args.run_on, SettingState.CMD_LINE)
+            args.run_on.value, SettingState.CMD_LINE)
     run_on = gv.settings.get_run_on()
 
     if args.run_checks:

--- a/CLI/add_solver.py
+++ b/CLI/add_solver.py
@@ -19,6 +19,7 @@ from CLI.help.command_help import CommandName
 from CLI.help import command_help as ch
 from CLI.initialise import check_for_initialise
 from CLI.help import argparse_custom as apc
+from sparkle.platform.settings_help import SettingState
 
 
 def parser_function() -> argparse.ArgumentParser:
@@ -68,7 +69,11 @@ if __name__ == "__main__":
         sys.exit(-1)
 
     nickname = args.nickname
-    run_on = args.run_on
+
+    if args.run_on is not None:
+        gv.settings.set_run_on(
+            args.run_on, SettingState.CMD_LINE)
+    run_on = gv.settings.get_run_on()
 
     if args.run_checks:
         print("Running checks...")

--- a/CLI/compute_features.py
+++ b/CLI/compute_features.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
 
     if args.run_on is not None:
         gv.settings.set_run_on(
-            args.run_on, SettingState.CMD_LINE)
+            args.run_on.value, SettingState.CMD_LINE)
     run_on = gv.settings.get_run_on()
 
     check_for_initialise(sys.argv,

--- a/CLI/compute_features.py
+++ b/CLI/compute_features.py
@@ -44,6 +44,11 @@ if __name__ == "__main__":
     # Process command line arguments
     args = parser.parse_args()
 
+    if args.run_on is not None:
+        gv.settings.set_run_on(
+            args.run_on, SettingState.CMD_LINE)
+    run_on = gv.settings.get_run_on()
+
     check_for_initialise(sys.argv,
                          ch.COMMAND_DEPENDENCIES[ch.CommandName.COMPUTE_FEATURES])
 
@@ -61,7 +66,7 @@ if __name__ == "__main__":
     # Start compute features
     print("Start computing features ...")
     scf.compute_features(gv.feature_data_csv_path,
-                         args.recompute, run_on=args.run_on)
+                         args.recompute, run_on=run_on)
 
     # Write used settings to file
     gv.settings.write_used_settings()

--- a/CLI/configure_solver.py
+++ b/CLI/configure_solver.py
@@ -97,7 +97,7 @@ def apply_settings_from_args(args: argparse.Namespace) -> None:
             args.number_of_runs, SettingState.CMD_LINE)
     if args.run_on is not None:
         gv.settings.set_run_on(
-            args.run_on, SettingState.CMD_LINE)
+            args.run_on.value, SettingState.CMD_LINE)
 
 
 def run_after(solver: Path,

--- a/CLI/configure_solver.py
+++ b/CLI/configure_solver.py
@@ -95,6 +95,9 @@ def apply_settings_from_args(args: argparse.Namespace) -> None:
     if args.number_of_runs is not None:
         gv.settings.set_config_number_of_runs(
             args.number_of_runs, SettingState.CMD_LINE)
+    if args.run_on is not None:
+        gv.settings.set_run_on(
+            args.run_on, SettingState.CMD_LINE)
 
 
 def run_after(solver: Path,
@@ -173,7 +176,7 @@ if __name__ == "__main__":
             gv.file_storage_data_mapping[gv.instances_nickname_path],
             gv.instance_dir, InstanceSet)
     use_features = args.use_features
-    run_on = args.run_on
+    run_on = gv.settings.get_run_on()
     if args.configurator is not None:
         gv.settings.set_general_sparkle_configurator(
             value=getattr(Configurator, args.configurator),

--- a/CLI/help/argparse_custom.py
+++ b/CLI/help/argparse_custom.py
@@ -337,7 +337,6 @@ RunExtractorLaterArgument = \
 
 RunOnArgument = ArgumentContainer(names=["--run-on"],
                                   kwargs={"type": Runner,
-                                          "default": Runner.SLURM,
                                           "choices": [Runner.LOCAL,
                                                       Runner.SLURM],
                                           "action": EnumAction,

--- a/CLI/run_ablation.py
+++ b/CLI/run_ablation.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
 
     if args.run_on is not None:
         gv.settings.set_run_on(
-            args.run_on, SettingState.CMD_LINE)
+            args.run_on.value, SettingState.CMD_LINE)
     run_on = gv.settings.get_run_on()
 
     check_for_initialise(sys.argv,

--- a/CLI/run_ablation.py
+++ b/CLI/run_ablation.py
@@ -82,7 +82,11 @@ if __name__ == "__main__":
         args.instance_set_test,
         gv.file_storage_data_mapping[gv.instances_nickname_path],
         gv.instance_dir, InstanceSet)
-    run_on = args.run_on
+
+    if args.run_on is not None:
+        gv.settings.set_run_on(
+            args.run_on, SettingState.CMD_LINE)
+    run_on = gv.settings.get_run_on()
 
     check_for_initialise(sys.argv,
                          ch.COMMAND_DEPENDENCIES[ch.CommandName.RUN_ABLATION])

--- a/CLI/run_configured_solver.py
+++ b/CLI/run_configured_solver.py
@@ -56,7 +56,11 @@ if __name__ == "__main__":
     if instance_set is None:
         print(f"Could not resolve instance (set): {args.instance_path}! Exiting...")
         sys.exit(-1)
-    run_on = args.run_on
+
+    if args.run_on is not None:
+        gv.settings.set_run_on(
+            args.run_on, SettingState.CMD_LINE)
+    run_on = gv.settings.get_run_on()
 
     check_for_initialise(sys.argv,
                          ch.COMMAND_DEPENDENCIES[ch.CommandName.RUN_CONFIGURED_SOLVER])

--- a/CLI/run_configured_solver.py
+++ b/CLI/run_configured_solver.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     if args.run_on is not None:
         gv.settings.set_run_on(
-            args.run_on, SettingState.CMD_LINE)
+            args.run_on.value, SettingState.CMD_LINE)
     run_on = gv.settings.get_run_on()
 
     check_for_initialise(sys.argv,

--- a/CLI/run_parallel_portfolio.py
+++ b/CLI/run_parallel_portfolio.py
@@ -256,7 +256,7 @@ if __name__ == "__main__":
 
     if args.run_on is not None:
         gv.settings.set_run_on(
-            args.run_on, SettingState.CMD_LINE)
+            args.run_on.value, SettingState.CMD_LINE)
     run_on = gv.settings.get_run_on()
 
     if run_on == Runner.LOCAL:

--- a/CLI/run_parallel_portfolio.py
+++ b/CLI/run_parallel_portfolio.py
@@ -253,7 +253,11 @@ if __name__ == "__main__":
         gv.settings.read_settings_ini(args.settings_file, SettingState.CMD_LINE)
 
     portfolio_path = args.portfolio_name
-    run_on = args.run_on
+
+    if args.run_on is not None:
+        gv.settings.set_run_on(
+            args.run_on, SettingState.CMD_LINE)
+    run_on = gv.settings.get_run_on()
 
     if run_on == Runner.LOCAL:
         print("Parallel Portfolio is not fully supported yet for Local runs. Exiting.")

--- a/CLI/run_solvers.py
+++ b/CLI/run_solvers.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
 
     if args.run_on is not None:
         gv.settings.set_run_on(
-            args.run_on, SettingState.CMD_LINE)
+            args.run_on.value, SettingState.CMD_LINE)
     run_on = gv.settings.get_run_on()
 
     check_for_initialise(sys.argv,

--- a/CLI/run_solvers.py
+++ b/CLI/run_solvers.py
@@ -205,9 +205,14 @@ if __name__ == "__main__":
         gv.settings.set_general_solution_verifier(
             SolutionVerifier.from_str(args.verifier), SettingState.CMD_LINE)
 
-    if args.target_cutoff_time:
+    if args.target_cutoff_time is not None:
         gv.settings.set_general_target_cutoff_time(
             args.target_cutoff_time, SettingState.CMD_LINE)
+
+    if args.run_on is not None:
+        gv.settings.set_run_on(
+            args.run_on, SettingState.CMD_LINE)
+    run_on = gv.settings.get_run_on()
 
     check_for_initialise(sys.argv,
                          sch.COMMAND_DEPENDENCIES[sch.CommandName.RUN_SOLVERS])
@@ -224,4 +229,4 @@ if __name__ == "__main__":
     run_solvers_on_instances(
         recompute=args.recompute,
         also_construct_selector_and_report=args.also_construct_selector_and_report,
-        run_on=args.run_on)
+        run_on=run_on)

--- a/CLI/run_sparkle_portfolio_selector.py
+++ b/CLI/run_sparkle_portfolio_selector.py
@@ -48,7 +48,12 @@ if __name__ == "__main__":
 
     # Process command line arguments
     args = parser.parse_args()
-    run_on = args.run_on
+
+    if args.run_on is not None:
+        gv.settings.set_run_on(
+            args.run_on, SettingState.CMD_LINE)
+    run_on = gv.settings.get_run_on()
+
     instance_set = resolve_object_name(
         args.instance_path,
         gv.file_storage_data_mapping[gv.instances_nickname_path],

--- a/CLI/run_sparkle_portfolio_selector.py
+++ b/CLI/run_sparkle_portfolio_selector.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
 
     if args.run_on is not None:
         gv.settings.set_run_on(
-            args.run_on, SettingState.CMD_LINE)
+            args.run_on.value, SettingState.CMD_LINE)
     run_on = gv.settings.get_run_on()
 
     instance_set = resolve_object_name(

--- a/CLI/validate_configured_vs_default.py
+++ b/CLI/validate_configured_vs_default.py
@@ -68,7 +68,11 @@ if __name__ == "__main__":
         args.instance_set_test,
         gv.file_storage_data_mapping[gv.instances_nickname_path],
         gv.instance_dir, InstanceSet)
-    run_on = args.run_on
+
+    if args.run_on is not None:
+        gv.settings.set_run_on(
+            args.run_on, SettingState.CMD_LINE)
+    run_on = gv.settings.get_run_on()
 
     check_for_initialise(
         sys.argv,

--- a/CLI/validate_configured_vs_default.py
+++ b/CLI/validate_configured_vs_default.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
 
     if args.run_on is not None:
         gv.settings.set_run_on(
-            args.run_on, SettingState.CMD_LINE)
+            args.run_on.value, SettingState.CMD_LINE)
     run_on = gv.settings.get_run_on()
 
     check_for_initialise(

--- a/Settings/sparkle_settings.ini
+++ b/Settings/sparkle_settings.ini
@@ -6,6 +6,7 @@ penalty_multiplier = 10
 solution_verifier = NONE
 extractor_cutoff_time = 60
 number_of_jobs_in_parallel = 25
+run_on = Runner.SLURM
 
 [configuration]
 wallclock_time = 600

--- a/Settings/sparkle_settings.ini
+++ b/Settings/sparkle_settings.ini
@@ -6,7 +6,7 @@ penalty_multiplier = 10
 solution_verifier = NONE
 extractor_cutoff_time = 60
 number_of_jobs_in_parallel = 25
-run_on = Runner.SLURM
+run_on = slurm
 
 [configuration]
 wallclock_time = 600

--- a/sparkle/platform/settings_help.py
+++ b/sparkle/platform/settings_help.py
@@ -14,6 +14,8 @@ from sparkle.types.objective import SparkleObjective
 from sparkle.configurator.configurator import Configurator
 from sparkle.configurator import implementations as cim
 
+from runrunner import Runner
+
 
 class SolutionVerifier(Enum):
     """Possible solution verifiers."""
@@ -100,6 +102,7 @@ class Settings:
         self.__config_solver_calls_set = SettingState.NOT_SET
         self.__config_number_of_runs_set = SettingState.NOT_SET
 
+        self.__run_on_set = SettingState.NOT_SET
         self.__number_of_jobs_in_parallel_set = SettingState.NOT_SET
         self.__slurm_max_parallel_runs_per_node_set = SettingState.NOT_SET
         self.__slurm_extra_options_set = dict()
@@ -187,6 +190,13 @@ class Settings:
                 if file_settings.has_option(section, option):
                     value = file_settings.getint(section, option)
                     self.set_number_of_jobs_in_parallel(value, state)
+                    file_settings.remove_option(section, option)
+
+            option_names = ("run_on", )
+            for option in option_names:
+                if file_settings.has_option(section, option):
+                    value = file_settings.get(section, option)
+                    self.set_run_on(value, state)
                     file_settings.remove_option(section, option)
 
             section = "configuration"
@@ -778,6 +788,22 @@ class Settings:
 
         return int(
             self.__settings["parallel_portfolio"]["num_seeds_per_solver"])
+
+    def set_run_on(self: Settings, value: Runner = Runner.SLURM,
+                   origin: SettingState = SettingState.DEFAULT) -> None:
+        """Set the compute on which to run."""
+        section = "general"
+        name = "run_on"
+
+        if value is not None and self.__check_setting_state(
+                self.__run_on_set, origin, name):
+            self.__init_section(section)
+            self.__run_on_set = origin
+            self.__settings[section][name] = value
+
+    def get_run_on(self: Settings) -> Runner:
+        """Return the compute on which to run."""
+        return self.__settings["general"]["run_on"]
 
     @staticmethod
     def check_settings_changes(cur_settings: Settings, prev_settings: Settings) -> bool:

--- a/sparkle/platform/settings_help.py
+++ b/sparkle/platform/settings_help.py
@@ -789,7 +789,7 @@ class Settings:
         return int(
             self.__settings["parallel_portfolio"]["num_seeds_per_solver"])
 
-    def set_run_on(self: Settings, value: Runner = Runner.SLURM,
+    def set_run_on(self: Settings, value: Runner = str,
                    origin: SettingState = SettingState.DEFAULT) -> None:
         """Set the compute on which to run."""
         section = "general"
@@ -803,7 +803,7 @@ class Settings:
 
     def get_run_on(self: Settings) -> Runner:
         """Return the compute on which to run."""
-        return Runner(self.__settings["general"]["run_on"])
+        return self.__settings["general"]["run_on"]
 
     @staticmethod
     def check_settings_changes(cur_settings: Settings, prev_settings: Settings) -> bool:

--- a/sparkle/platform/settings_help.py
+++ b/sparkle/platform/settings_help.py
@@ -803,7 +803,7 @@ class Settings:
 
     def get_run_on(self: Settings) -> Runner:
         """Return the compute on which to run."""
-        return self.__settings["general"]["run_on"]
+        return Runner(self.__settings["general"]["run_on"])
 
     @staticmethod
     def check_settings_changes(cur_settings: Settings, prev_settings: Settings) -> bool:


### PR DESCRIPTION
The default value is stored in the file Settings/sparkle_settings.ini and can be changed by the user to meet their needs. Additionally, its value can be overwritten when running a command and passing the option "--run-on" (followed by the desired value) via the command line. Note that this second way of specifying the option is not persistent and only has an effect on the current command.