### PR TITLE
Sprk 338

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to Sparkle will be documented in this file.
 
+## [0.9.0] - 2024/??/??
+- Added cancel command to Sparkle to cancel Slurm jobs including interactive table to make your selection [SPRK-338]
+
 ## [0.8.9] - 2024/09/27
 - Various updates to Documentation, automated testing and CI pipelines
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(name="SparkleAI",
           "pandas==2.2.2",
           "filelock==3.15.1",
           "tabulate==0.9.0",
+          "pytermgui==7.7.2",
           "tqdm==4.66.5",
           "RunRunner==0.1.6.4",
           # Reporting packages

--- a/sparkle/CLI/cancel.py
+++ b/sparkle/CLI/cancel.py
@@ -1,0 +1,48 @@
+"""Command to cancel async jobs."""
+import sys
+import argparse
+
+from runrunner.base import Status
+
+from sparkle.CLI.help import logging
+from sparkle.CLI.help import argparse_custom as ac
+from sparkle.CLI.help import jobs as jobs_help
+from sparkle.CLI.help import global_variables as gv
+
+
+def parser_function() -> argparse.ArgumentParser:
+    """Create parser for the cancel command."""
+    parser = argparse.ArgumentParser(description="Sparkle cancel command.")
+    parser.add_argument(*ac.JobIDsArgument.names, **ac.JobIDsArgument.kwargs)
+    parser.add_argument(*ac.AllJobsArgument.names, **ac.AllJobsArgument.kwargs)
+    return parser
+
+
+def main(argv: list[str]) -> None:
+    """Main function of the cancel command."""
+    # Log command call
+    logging.log_command(sys.argv)
+
+    # Define command line arguments
+    parser = parser_function()
+
+    # Process command line arguments
+    args = parser.parse_args(argv)
+
+    # Filter jobs on relevant status
+    path = gv.settings().DEFAULT_log_output
+    jobs = [run for run in jobs_help.get_runs_from_file(path)
+            if run.status == Status.WAITING or run.status == Status.RUNNING]
+
+    if args.all or args.job_ids:
+        for j in jobs:
+            if args.all or j.run_id in args.job_ids:
+                j.kill()
+    else:
+        # TODO: Make selection table
+        print("No jobs to cancel!")
+    sys.exit()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/sparkle/CLI/cancel.py
+++ b/sparkle/CLI/cancel.py
@@ -45,7 +45,7 @@ def main(argv: list[str]) -> None:
         if len(killed_jobs) == 0:
             if args.all:
                 print("No jobs to cancel.")
-                sys.exit()
+                sys.exit(0)
             else:
                 print(f"ERROR: No jobs with ids {args.job_ids} to cancel.")
                 # NOTE: Should we raise an error here instead?
@@ -97,7 +97,7 @@ def main(argv: list[str]) -> None:
 
             manager.add(window)
 
-    sys.exit()
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/sparkle/CLI/cancel.py
+++ b/sparkle/CLI/cancel.py
@@ -2,6 +2,7 @@
 """Command to cancel async jobs."""
 import sys
 import argparse
+import signal
 
 from runrunner.base import Status
 
@@ -36,12 +37,45 @@ def main(argv: list[str]) -> None:
             if run.status == Status.WAITING or run.status == Status.RUNNING]
 
     if args.all or args.job_ids:
+        killed_jobs = []
         for j in jobs:
             if args.all or j.run_id in args.job_ids:
                 j.kill()
+                killed_jobs.append(j)
+        if len(killed_jobs) == 0:
+            if args.all:
+                print("No jobs to cancel.")
+                sys.exit()
+            else:
+                print(f"ERROR: No jobs with ids {args.job_ids} to cancel.")
+                # NOTE: Should we raise an error here instead?
+                sys.exit(-1)
+        else:
+            print(f"Canceled {len(killed_jobs)} jobs with IDs: "
+                  f"{', '.join([j.run_id for j in killed_jobs])}.")
     else:
-        # TODO: Make selection table
-        print("No jobs to cancel!")
+        def signal_handler(num: int, _: any) -> None:
+            """Create clean exit for CTRL + C."""
+            if num == signal.SIGINT:
+                sys.exit()
+        signal.signal(signal.SIGINT, signal_handler)
+
+        print("Select a job to cancel:")
+        while any(j.status == Status.WAITING or j.status == Status.RUNNING
+                  for j in jobs):
+            table = jobs_help.create_jobs_table(jobs)
+            print(table)
+
+            # TODO: Handle input for selecting jobs
+
+            # Clears the table for the new table to be printed
+            lines = table.count("\n") + 1
+            # \033 is the escape character (ESC),
+            # [{lines}A is the escape sequence that moves the cursor up.
+            print(f"\033[{lines}A", end="")
+            # [J is the escape sequence that clears the console from the cursor down
+            print("\033[J", end="")
+
     sys.exit()
 
 

--- a/sparkle/CLI/cancel.py
+++ b/sparkle/CLI/cancel.py
@@ -2,7 +2,7 @@
 """Command to cancel async jobs."""
 import sys
 import argparse
-import signal
+import pytermgui as ptg
 
 from runrunner.base import Status
 
@@ -53,28 +53,49 @@ def main(argv: list[str]) -> None:
         else:
             print(f"Canceled {len(killed_jobs)} jobs with IDs: "
                   f"{', '.join([j.run_id for j in killed_jobs])}.")
+    elif len(jobs) == 0:
+        print("No jobs available to cancel.")
     else:
-        def signal_handler(num: int, _: any) -> None:
-            """Create clean exit for CTRL + C."""
-            if num == signal.SIGINT:
-                sys.exit()
-        signal.signal(signal.SIGINT, signal_handler)
+        jobs = sorted(jobs, key=lambda j: j.run_id)
+        ptg.Button.chars = {"delimiter": ["", ""]}  # Disable padding around buttons
 
-        print("Select a job to cancel:")
-        while any(j.status == Status.WAITING or j.status == Status.RUNNING
-                  for j in jobs):
-            table = jobs_help.create_jobs_table(jobs)
-            print(table)
+        def cancel_jobs(self: ptg.Button) -> None:
+            """Cancel jobs based on a button click."""
+            job_id = self.label.split("|")[1].strip()
+            for job in jobs:
+                if job.run_id == job_id:
+                    job.kill()
+                    # Replace button with label
+                    for iw, widget in enumerate(self.parent._widgets):
+                        if isinstance(widget, ptg.Button) and \
+                                widget.label == self.label:
+                            self.parent._widgets[iw] = ptg.Label(self.label)
+                    break
+            refresh_data(self.parent)
 
-            # TODO: Handle input for selecting jobs
+        def refresh_data(self: ptg.Window) -> None:
+            """Refresh the table."""
+            data_table = jobs_help.create_jobs_table(jobs, markup=True).splitlines()
+            for iw, widget in enumerate(self._widgets):
+                self._widgets[iw] = type(widget)(data_table[iw], onclick=cancel_jobs)
+                self._widgets[iw].parent = self
 
-            # Clears the table for the new table to be printed
-            lines = table.count("\n") + 1
-            # \033 is the escape character (ESC),
-            # [{lines}A is the escape sequence that moves the cursor up.
-            print(f"\033[{lines}A", end="")
-            # [J is the escape sequence that clears the console from the cursor down
-            print("\033[J", end="")
+        table = jobs_help.create_jobs_table(jobs, markup=True).splitlines()
+        with ptg.WindowManager() as manager:
+            window = (
+                ptg.Window(
+                    width=len(table[0]),
+                    box="EMPTY",
+                )
+                .set_title("Running Sparkle Jobs")
+            )
+            for row in table:
+                if "|" not in row or not row.split("|")[1].strip().isnumeric():
+                    window._add_widget(ptg.Label(row))
+                else:
+                    window._add_widget(ptg.Button(label=row, onclick=cancel_jobs))
+
+            manager.add(window)
 
     sys.exit()
 

--- a/sparkle/CLI/cancel.py
+++ b/sparkle/CLI/cancel.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Command to cancel async jobs."""
 import sys
 import argparse

--- a/sparkle/CLI/configure_solver.py
+++ b/sparkle/CLI/configure_solver.py
@@ -139,14 +139,15 @@ def run_after(solver: Path,
     return run
 
 
-if __name__ == "__main__":
+def main(argv: list[str]) -> None:
+    """Main function of the configure solver command."""
     # Log command call
     sl.log_command(sys.argv)
 
     parser = parser_function()
 
     # Process command line arguments
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     apply_settings_from_args(args)
 
@@ -265,3 +266,7 @@ if __name__ == "__main__":
     gv.settings().write_used_settings()
     # Write used scenario to file
     gv.latest_scenario().write_scenario_ini()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/sparkle/CLI/help/argparse_custom.py
+++ b/sparkle/CLI/help/argparse_custom.py
@@ -86,18 +86,17 @@ AblationArgument = ArgumentContainer(names=["--ablation"],
                                      kwargs={"required": False,
                                              "action": "store_true",
                                              "help": "run ablation after configuration"})
-SelectorAblationArgument =\
-    ArgumentContainer(names=["--solver-ablation"],
-                      kwargs={"required": False,
-                              "action": "store_true",
-                              "help": "construct a selector for "
-                                      "each solver ablation combination"})
 
 ActualMarginalContributionArgument = \
     ArgumentContainer(names=["--actual"],
                       kwargs={"action": "store_true",
                               "help": "compute the marginal contribution "
                                       "for the actual selector"})
+
+AllJobsArgument = \
+    ArgumentContainer(names=["--all"],
+                      kwargs={"action": "store_true",
+                              "help": "use all known job ID(s) for the command"})
 
 AlsoConstructSelectorAndReportArgument = \
     ArgumentContainer(names=["--also-construct-selector-and-report"],
@@ -222,7 +221,7 @@ JobIDsArgument = ArgumentContainer(names=["--job-ids"],
                                            "nargs": "+",
                                            "type": str,
                                            "default": None,
-                                           "help": "job ID to wait for"})
+                                           "help": "job ID(s) to use for the command"})
 
 NicknameFeatureExtractorArgument = \
     ArgumentContainer(names=["--nickname"],
@@ -342,6 +341,13 @@ SelectionReportArgument = \
     ArgumentContainer(names=["--selection"],
                       kwargs={"action": "store_true",
                               "help": "set to generate a normal selection report"})
+
+SelectorAblationArgument =\
+    ArgumentContainer(names=["--solver-ablation"],
+                      kwargs={"required": False,
+                              "action": "store_true",
+                              "help": "construct a selector for "
+                                      "each solver ablation combination"})
 
 SettingsFileArgument = \
     ArgumentContainer(names=["--settings-file"],

--- a/sparkle/CLI/help/jobs.py
+++ b/sparkle/CLI/help/jobs.py
@@ -59,11 +59,12 @@ def create_jobs_table(jobs: list[SlurmRun], markup: bool = True) -> str:
             status_text = job.status
         information.append(
             [job.run_id,
-                job.name,
-                job.partition,
-                status_text,
-                "None" if len(job.dependencies) == 0
-                else ", ".join(job.dependencies),
-                f"{finished_jobs_count}/{len(job.all_status)}",
-                job.runtime])
-    return tabulate(information, headers="firstrow", tablefmt="grid")
+             job.name,
+             job.partition,
+             status_text,
+             "None" if len(job.dependencies) == 0 else ", ".join(job.dependencies),
+             f"{finished_jobs_count}/{len(job.all_status)}",
+             job.runtime])
+    if markup:
+        return tabulate(information, headers="firstrow", tablefmt="grid")
+    return information

--- a/sparkle/CLI/help/jobs.py
+++ b/sparkle/CLI/help/jobs.py
@@ -1,7 +1,12 @@
 """File to help with RunRunner jobs."""
 from pathlib import Path
 
+from tabulate import tabulate
+
+from runrunner.base import Status
 from runrunner.slurm import SlurmRun
+
+from sparkle.platform.cli_types import TEXT
 
 
 def get_runs_from_file(path: Path, print_error: bool = False) -> list[SlurmRun]:
@@ -25,3 +30,40 @@ def get_runs_from_file(path: Path, print_error: bool = False) -> list[SlurmRun]:
             if print_error:
                 print(f"[WARNING] Could not load file: {file}. Exception: {ex}")
     return runs
+
+
+def create_jobs_table(jobs: list[SlurmRun], markup: bool = True) -> str:
+    """Create a table of jobs.
+
+    Args:
+        runs: List of SlurmRun objects.
+        markup: By default some mark up will be applied to the table.
+            If false, a more plain version will be created.
+
+    Returns:
+        A table of jobs as a string.
+    """
+    information = [["RunId", "Name", "Partition", "Status",
+                    "Dependencies", "Finished Jobs", "Run Time"]]
+    for job in jobs:
+        # Count number of jobs that have finished
+        finished_jobs_count = sum(1 for status in job.all_status
+                                  if status == Status.COMPLETED)
+        if markup:  # Format job.status
+            status_text = \
+                TEXT.format_text([TEXT.BOLD], job.status) \
+                if job.status == Status.RUNNING else \
+                (TEXT.format_text([TEXT.ITALIC], job.status)
+                    if job.status == Status.COMPLETED else job.status)
+        else:
+            status_text = job.status
+        information.append(
+            [job.run_id,
+                job.name,
+                job.partition,
+                status_text,
+                "None" if len(job.dependencies) == 0
+                else ", ".join(job.dependencies),
+                f"{finished_jobs_count}/{len(job.all_status)}",
+                job.runtime])
+    return tabulate(information, headers="firstrow", tablefmt="grid")

--- a/sparkle/CLI/help/jobs.py
+++ b/sparkle/CLI/help/jobs.py
@@ -43,8 +43,8 @@ def create_jobs_table(jobs: list[SlurmRun], markup: bool = True) -> str:
     Returns:
         A table of jobs as a string.
     """
-    information = [["RunId", "Name", "Partition", "Status",
-                    "Dependencies", "Finished Jobs", "Run Time"]]
+    job_table = [["RunId", "Name", "Partition", "Status",
+                  "Dependencies", "Finished Jobs", "Run Time"]]
     for job in jobs:
         # Count number of jobs that have finished
         finished_jobs_count = sum(1 for status in job.all_status
@@ -57,7 +57,7 @@ def create_jobs_table(jobs: list[SlurmRun], markup: bool = True) -> str:
                     if job.status == Status.COMPLETED else job.status)
         else:
             status_text = job.status
-        information.append(
+        job_table.append(
             [job.run_id,
              job.name,
              job.partition,
@@ -66,5 +66,5 @@ def create_jobs_table(jobs: list[SlurmRun], markup: bool = True) -> str:
              f"{finished_jobs_count}/{len(job.all_status)}",
              job.runtime])
     if markup:
-        return tabulate(information, headers="firstrow", tablefmt="grid")
-    return information
+        return tabulate(job_table, headers="firstrow", tablefmt="grid")
+    return job_table

--- a/sparkle/CLI/help/jobs.py
+++ b/sparkle/CLI/help/jobs.py
@@ -1,0 +1,27 @@
+"""File to help with RunRunner jobs."""
+from pathlib import Path
+
+from runrunner.slurm import SlurmRun
+
+
+def get_runs_from_file(path: Path, print_error: bool = False) -> list[SlurmRun]:
+    """Retrieve all run objects from file storage.
+
+    Args:
+        path: Path object where to look recursively for the files.
+
+    Returns:
+        List of all found SlumRun objects.
+    """
+    runs = []
+    for file in path.rglob("*.json"):
+        # TODO: RunRunner should be adapted to have more general methods for runs
+        # So this method can work for both local and slurm
+        try:
+            run_obj = SlurmRun.from_file(file)
+            runs.append(run_obj)
+        except Exception as ex:
+            # Not a (correct) RunRunner JSON file
+            if print_error:
+                print(f"[WARNING] Could not load file: {file}. Exception: {ex}")
+    return runs

--- a/sparkle/CLI/help/logging.py
+++ b/sparkle/CLI/help/logging.py
@@ -115,7 +115,8 @@ def log_command(argv: list[str]) -> None:
         log_str = log_header + log_str
 
     # Write to log file
-    log_path.open("a").write(log_str)
+    with log_path.open("a") as log_file:
+        log_file.write(log_str)
 
     # Pipe RunRunner log to the caller log
     RunRunnerLog.set_log_file(caller_log_path)

--- a/tests/CLI/test_cancel.py
+++ b/tests/CLI/test_cancel.py
@@ -1,0 +1,83 @@
+"""Test the cancel CLI entry point."""
+import pytest
+from pathlib import Path
+
+from sparkle.CLI import initialise, cancel, add_solver, add_instances, configure_solver
+from sparkle.CLI.help import jobs as jobs_help
+from sparkle.CLI.help import global_variables as gv
+
+from runrunner.base import Status
+
+
+@pytest.mark.integration
+def test_cancel_command_no_jobs(tmp_path: Path,
+                                monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test cancel command with no jobs."""
+    return
+    monkeypatch.chdir(tmp_path)  # Execute in PyTest tmp dir
+    # Smoke test
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        # Call the command
+        initialise.main([])
+        # Check the exit status
+    assert pytest_wrapped_e.type is SystemExit
+    assert pytest_wrapped_e.value.code == 0
+
+    # Test with nothing to cancel
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        cancel.main(["--all"])
+    assert pytest_wrapped_e.type is SystemExit
+    assert pytest_wrapped_e.value.code == 0
+
+    # Test with an ID that does not exist
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        cancel.main(["--job-ids", "1234"])
+    assert pytest_wrapped_e.type is SystemExit
+    assert pytest_wrapped_e.value.code == -1
+
+
+@pytest.mark.integration
+def test_cancel_command_configuration(tmp_path: Path,
+                                      monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test cancel command on configuration jobs."""
+    return
+    # Submit configuration jobs and cancel it by ID
+    solver_path =\
+        (Path("Examples") / "Resources" / "Solvers" / "PbO-CCSAT-Generic").absolute()
+    instance_set_path =\
+        (Path("Examples") / "Resources" / "Instances" / "PTN").absolute()
+    monkeypatch.chdir(tmp_path)  # Execute in PyTest tmp dir
+
+    # Add solver
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        add_solver.main([str(solver_path)])
+    assert pytest_wrapped_e.type is SystemExit
+    assert pytest_wrapped_e.value.code == 0
+
+    # Add instances
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        add_instances.main([str(instance_set_path)])
+    assert pytest_wrapped_e.type is SystemExit
+    assert pytest_wrapped_e.value.code == 0
+
+    # Submit configure solver job and validation job
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        configure_solver.main(["--solver", solver_path.name,
+                               "--instance-set", instance_set_path.name])
+    assert pytest_wrapped_e.type is SystemExit
+    assert pytest_wrapped_e.value.code == 0
+
+    # Extract job IDs from Sparkle
+    jobs = jobs_help.get_runs_from_file(gv.settings().DEFAULT_log_output)
+
+    # Cancel configuration jobs
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        cancel.main(["--job-ids"] + [str(job.run_id) for job in jobs])
+    assert pytest_wrapped_e.type is SystemExit
+    assert pytest_wrapped_e.value.code == 0
+
+    # Property checks
+    assert len(jobs) == 2  # Configuration should submit have 2 jobs
+
+    for job in jobs:  # All jobs have been cancelled
+        assert job.status == Status.KILLED


### PR DESCRIPTION
Creating new Sparkle command to help with cancelling started slurm jobs

- Includes --all argument to kill all known waiting or running slurm jobs
- Includes --job-ids argument to kill jobs with specific id(s)
- Includes check for if any jobs are available for cancellation
- Includes interactive table to select jobs to cancel (Uses the same table as the Sparkle wait command)