### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ADA-research/Sparkle/security/code-scanning/8](https://github.com/ADA-research/Sparkle/security/code-scanning/8)

Add an explicit `permissions` block to `.github/workflows/linter.yml` at the workflow root level (recommended here since there is one job and the same minimum scope applies across it).  
The minimal safe permission for this workflow is:

- `contents: read`

This preserves existing behavior (checkout/lint/artifact upload still work) while ensuring `GITHUB_TOKEN` is restricted.

Edit region: near the top of `.github/workflows/linter.yml`, directly after `on:` (or before `jobs:`), adding:

```yml
permissions:
  contents: read
```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
