### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - src/sparkle/**
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ADA-research/Sparkle/security/code-scanning/7](https://github.com/ADA-research/Sparkle/security/code-scanning/7)

Add an explicit `permissions` block to `.github/workflows/unittest.yml` so the workflow does not rely on repository/org defaults.  
Best fix without changing functionality: set workflow-level permissions to the minimum needed, i.e. `contents: read`. This supports `actions/checkout` and typical read operations while preventing unnecessary write scopes.

Change location:
- File: `.github/workflows/unittest.yml`
- Insert directly after the `on:` trigger block (before `jobs:`), or at top-level before `jobs:`.

No imports, methods, or dependencies are needed—just YAML configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
