### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,10 @@ on:
     pull_request:
         branches: ["development", "main"]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
 
   changelog:


### PR DESCRIPTION
Potential fix for [https://github.com/ADA-research/Sparkle/security/code-scanning/2](https://github.com/ADA-research/Sparkle/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/changelog.yml` to restrict the `GITHUB_TOKEN` to only what this workflow needs. Since this job enforces changelog behavior on pull requests and does not need repository write access, the safest baseline is:

- `contents: read`
- `pull-requests: read`

Apply this at the workflow root (after `on:`) so it covers all jobs unless overridden. This resolves the CodeQL finding without changing workflow behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
